### PR TITLE
Provide original error to callback instead of request.

### DIFF
--- a/build.go
+++ b/build.go
@@ -33,6 +33,8 @@ func relativeFilePath(a, b string) (r string, e error) {
 
 func commonJSImports(conf *config.Config, c *code, tsFilename string) {
 	c.l("// hello commonjs - we need some imports - sorted in alphabetical order, by go package")
+	c.l("/* tslint:disable */")
+
 	packageNames := []string{}
 	for packageName := range conf.Mappings {
 		packageNames = append(packageNames, packageName)

--- a/typescript.go
+++ b/typescript.go
@@ -306,7 +306,7 @@ func RenderTypeScriptServices(moduleKind config.ModuleKind, services ServiceList
 					var data = JSON.parse(request.responseText);
 					success.apply(null, data);
 				} catch(e) {
-	                err(request);
+	                err(e);
 				}
             } else {
                 err(request);


### PR DESCRIPTION
* [x] Provide the originally raised error to the error callback.
This is especially useful when an error is raised in the call stack of the success handler, eg: The request was successful, but the success handler dispatches an invalid Redux-action. Current behaviour: The error callback gets called with the successful request, the original error disappears into the eternal hunting grounds of never-catched Javascript-errors.

* [ ] Add a `tslint:disable` header by default. this does not break anything because it's a comment but prevents tslint from checking the generated file at all.