### PR TITLE
Disable TSLint in generated files.

### DIFF
--- a/build.go
+++ b/build.go
@@ -33,6 +33,7 @@ func relativeFilePath(a, b string) (r string, e error) {
 }
 
 func commonJSImports(conf *config.Config, c *code, tsFilename string) {
+	c.l("// tslint:disable")
 	c.l("// hello commonjs - we need some imports - sorted in alphabetical order, by go package")
 	packageNames := []string{}
 	for packageName := range conf.Mappings {


### PR DESCRIPTION
Add header comment `// tslint:disable` in each generated file to disable TSLint validation.

This PR is pretty small but has quite a big impact on us, thanks for looking into it.