### PR TITLE
prometheus: Remove unnecessary shallow copy (alloc) of http.Request

### DIFF
--- a/prometheus/prometheus.go
+++ b/prometheus/prometheus.go
@@ -25,7 +25,7 @@ func InstrumentService(s http.HandlerFunc) (handler http.HandlerFunc) {
 	p.MustRegister(requestDuration)
 
 	return func(w http.ResponseWriter, r *http.Request) {
-		*r = *gotsrpc.RequestWithStatsContext(r)
+		r = gotsrpc.RequestWithStatsContext(r)
 		s.ServeHTTP(w, r)
 		stats := gotsrpc.GetStatsForRequest(r)
 		if stats != nil {


### PR DESCRIPTION
The copy already happens in http.Request.WithContext in function
RequestWithStatsContext.