### PR TITLE
feat: add tsImportExtension config for TypeScript import paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	Targets map[string]*Target `json:"targets" yaml:"targets"`
 	// Map of go module names to TypeScript mapping settings
 	Mappings TypeScriptMappings `json:"mappings" yaml:"mappings"`
+	// Optional file extension to append to relative TypeScript import paths (e.g. ".js")
+	TSImportExtension string `json:"tsImportExtension" yaml:"tsImportExtension"`
 }
 
 func LoadConfigFile(file string) (conf *Config, err error) {

--- a/gotsrpc.schema.json
+++ b/gotsrpc.schema.json
@@ -16,6 +16,10 @@
         },
         "mappings": {
           "$ref": "#/$defs/TypeScriptMappings"
+        },
+        "tsImportExtension": {
+          "description": "Optional file extension to append to relative TypeScript import paths (e.g. '.js'). Required for TypeScript projects using moduleResolution 'nodenext' or 'node16'.",
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -278,13 +278,13 @@ func deriveCommonJSMapping(conf *config.Config) {
 	}
 }
 
-func relativeFilePath(a, b string) (r string, e error) {
+func relativeFilePath(a, b, ext string) (r string, e error) {
 	r, e = filepath.Rel(path.Dir(a), b)
 	if e != nil {
 		return
 	}
 
-	r = strings.TrimSuffix(r, ".ts")
+	r = strings.TrimSuffix(r, ".ts") + ext
 
 	return
 }
@@ -304,7 +304,7 @@ func commonJSImports(conf *config.Config, c *codegen.Code, tsFilename string, co
 			continue
 		}
 
-		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out)
+		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out, conf.TSImportExtension)
 		if relativeErr != nil {
 			fmt.Println("can not derive a relative path between", tsFilename, "and", importMapping.Out, relativeErr)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

Adds a new top-level `tsImportExtension` config option that appends a file extension to relative import paths in generated TypeScript files.

**Problem:** TypeScript 6 deprecated `moduleResolution: "node10"`, and TypeScript 7 will remove it entirely. Projects using `"nodenext"` or `"node16"` resolution require explicit `.js` extensions on relative imports — but gotsrpc currently generates extensionless imports like:

```typescript
import * as foo from './vo-constants';
```

**Solution:** When `tsImportExtension: ".js"` is set in the YAML config, generated imports become:

```typescript
import * as foo from './vo-constants.js';
```

The option defaults to `""` (empty string), so **existing behavior is unchanged** — this is fully backwards compatible.

## Usage

```yaml
module:
  name: github.com/example/project
  path: ./

tsImportExtension: ".js"

targets:
  # ...
mappings:
  # ...
```

## Changes

- **`config/config.go`** — Add `TSImportExtension` field to `Config` struct
- **`internal/build/build.go`** — Pass `conf.TSImportExtension` through `relativeFilePath()` → appended after stripping `.ts`
- **`gotsrpc.schema.json`** — Add `tsImportExtension` to the JSON schema

## Why this matters

- TypeScript 7 will remove `moduleResolution: "node10"` — projects need `"nodenext"` or `"bundler"`
- `"nodenext"` requires `.js` extensions on relative imports
- Without this option, consumers must post-process generated files with sed/scripts
- `.js` extensions are valid across **all** TS resolution modes, so opting in is always safe