### PR TITLE
feat: add tsImportJsExtension config to append .js to TS import paths

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -71,6 +71,8 @@ type Config struct {
 	Targets map[string]*Target `json:"targets" yaml:"targets"`
 	// Map of go module names to TypeScript mapping settings
 	Mappings TypeScriptMappings `json:"mappings" yaml:"mappings"`
+	// Optional file extension to append to relative TypeScript import paths (e.g. ".js")
+	TSImportExtension string `json:"tsImportExtension" yaml:"tsImportExtension"`
 }
 
 func LoadConfigFile(file string) (conf *Config, err error) {

--- a/config/config.go
+++ b/config/config.go
@@ -71,8 +71,9 @@ type Config struct {
 	Targets map[string]*Target `json:"targets" yaml:"targets"`
 	// Map of go module names to TypeScript mapping settings
 	Mappings TypeScriptMappings `json:"mappings" yaml:"mappings"`
-	// Optional file extension to append to relative TypeScript import paths (e.g. ".js")
-	TSImportExtension string `json:"tsImportExtension" yaml:"tsImportExtension"`
+	// When true, appends .js extension to relative TypeScript import paths.
+	// Required for TypeScript projects using moduleResolution 'nodenext' or 'node16'.
+	TSImportJsExtension bool `json:"tsImportJsExtension" yaml:"tsImportJsExtension"`
 }
 
 func LoadConfigFile(file string) (conf *Config, err error) {

--- a/gotsrpc.schema.json
+++ b/gotsrpc.schema.json
@@ -18,7 +18,6 @@
           "$ref": "#/$defs/TypeScriptMappings"
         },
         "tsImportExtension": {
-          "description": "Optional file extension to append to relative TypeScript import paths (e.g. '.js'). Required for TypeScript projects using moduleResolution 'nodenext' or 'node16'.",
           "type": "string"
         }
       },

--- a/gotsrpc.schema.json
+++ b/gotsrpc.schema.json
@@ -16,6 +16,10 @@
         },
         "mappings": {
           "$ref": "#/$defs/TypeScriptMappings"
+        },
+        "tsImportExtension": {
+          "description": "Optional file extension to append to relative TypeScript import paths (e.g. '.js'). Required for TypeScript projects using moduleResolution 'nodenext' or 'node16'.",
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/gotsrpc.schema.json
+++ b/gotsrpc.schema.json
@@ -17,8 +17,8 @@
         "mappings": {
           "$ref": "#/$defs/TypeScriptMappings"
         },
-        "tsImportExtension": {
-          "type": "string"
+        "tsImportJsExtension": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -278,13 +278,13 @@ func deriveCommonJSMapping(conf *config.Config) {
 	}
 }
 
-func relativeFilePath(a, b string) (r string, e error) {
+func relativeFilePath(a, b, ext string) (r string, e error) {
 	r, e = filepath.Rel(path.Dir(a), b)
 	if e != nil {
 		return
 	}
 
-	r = strings.TrimSuffix(r, ".ts")
+	r = strings.TrimSuffix(r, ".ts") + ext
 
 	return
 }
@@ -304,7 +304,7 @@ func commonJSImports(conf *config.Config, c *codegen.Code, tsFilename string, co
 			continue
 		}
 
-		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out)
+		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out, conf.TSImportExtension)
 		if relativeErr != nil {
 			fmt.Println("can not derive a relative path between", tsFilename, "and", importMapping.Out, relativeErr)
 			os.Exit(1)

--- a/internal/build/build.go
+++ b/internal/build/build.go
@@ -278,13 +278,16 @@ func deriveCommonJSMapping(conf *config.Config) {
 	}
 }
 
-func relativeFilePath(a, b, ext string) (r string, e error) {
+func relativeFilePath(a, b string, appendJsExtension bool) (r string, e error) {
 	r, e = filepath.Rel(path.Dir(a), b)
 	if e != nil {
 		return
 	}
 
-	r = strings.TrimSuffix(r, ".ts") + ext
+	r = strings.TrimSuffix(r, ".ts")
+	if appendJsExtension {
+		r += ".js"
+	}
 
 	return
 }
@@ -304,7 +307,7 @@ func commonJSImports(conf *config.Config, c *codegen.Code, tsFilename string, co
 			continue
 		}
 
-		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out, conf.TSImportExtension)
+		relativePath, relativeErr := relativeFilePath(tsFilename, importMapping.Out, conf.TSImportJsExtension)
 		if relativeErr != nil {
 			fmt.Println("can not derive a relative path between", tsFilename, "and", importMapping.Out, relativeErr)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

Adds a new top-level `tsImportJsExtension` boolean config option that, when `true`, appends `.js` to relative import paths in generated TypeScript files.

**Problem:** TypeScript 6 deprecated `moduleResolution: "node10"`, and TypeScript 7 will remove it entirely. Projects using `"nodenext"` or `"node16"` resolution require explicit `.js` extensions on relative imports — but gotsrpc currently generates extensionless imports like:

```typescript
import * as foo from './vo-constants';
```

**Solution:** When `tsImportJsExtension: true` is set in the YAML config, generated imports become:

```typescript
import * as foo from './vo-constants.js';
```

The option defaults to `false`, so **existing behavior is unchanged** — this is fully backwards compatible.

## Usage

```yaml
module:
  name: github.com/example/project
  path: ./

tsImportJsExtension: true

targets:
  # ...
mappings:
  # ...
```

## Changes

- **`config/config.go`** — Add `TSImportJsExtension bool` field to `Config` struct
- **`internal/build/build.go`** — Pass `conf.TSImportJsExtension` to `relativeFilePath()` → appends `.js` after stripping `.ts`
- **`gotsrpc.schema.json`** — Add `tsImportJsExtension` boolean to the JSON schema

## Why boolean instead of string

The first iteration used a string field (`tsImportExtension: ".js"`) for flexibility. But in practice `.js` is the only extension that makes sense — it works across all TypeScript resolution modes (`bundler`, `nodenext`, `node16`), and the alternatives (`.mjs`/`.cjs`) are for niche setups where packages explicitly separate ESM and CJS output files.

Using a boolean simplifies the API: users don't need to know what value to set, there's no room for misuse, and the docs are clearer.

## Why this matters

- TypeScript 7 will remove `moduleResolution: "node10"` — projects need `"nodenext"` or `"bundler"`
- `"nodenext"` requires `.js` extensions on relative imports
- Without this option, consumers must post-process generated files with sed/scripts
- `.js` extensions are valid across **all** TS resolution modes, so opting in is always safe