### PR TITLE
chore: housekeeping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,33 +1,49 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/SchemaStore/schemastore/refs/heads/master/src/schemas/json/dependabot-2.0.json
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
 version: 2
 
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 updates:
   - package-ecosystem: github-actions
-    open-pull-requests-limit: 1
-    commit-message: { prefix: 'chore(deps)' }
+    commit-message: { prefix: sec(gha) }
+    open-pull-requests-limit: 0
     directory: '/'
     schedule:
-      day: sunday
-      interval: weekly
-      timezone: Europe/Berlin
-    cooldown:
-      default-days: 1
-
-  - package-ecosystem: gomod
-    open-pull-requests-limit: 1
-    commit-message: { prefix: 'sec(deps)' }
-    directories: [ '**/*' ]
-    schedule:
       interval: daily
+      timezone: Europe/Berlin
     groups:
       security:
         applies-to: security-updates
-        update-types: [ minor, patch ]
-    ignore:
-      - dependency-name: '*'
-        update-types: [ 'version-update:semver-major' ]
+        group-by: dependency-name
+        patterns: ['*']
     cooldown:
-      default-days: 1
-      semver-major-days: 14
-      semver-minor-days: 7
-      semver-patch-days: 1
+      default-days: 3
+
+  - package-ecosystem: gomod
+    commit-message: { prefix: sec(gomod) }
+    open-pull-requests-limit: 0
+    directories: [ '**/*' ]
+    schedule:
+      interval: daily
+      timezone: Europe/Berlin
+    groups:
+      security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ['*']
+    cooldown:
+      default-days: 3
+
+  - package-ecosystem: docker
+    commit-message: { prefix: sec(docker) }
+    open-pull-requests-limit: 0
+    directory: '/'
+    schedule:
+      interval: daily
+      timezone: Europe/Berlin
+    groups:
+      security:
+        applies-to: security-updates
+        group-by: dependency-name
+        patterns: ['*']
+    cooldown:
+      default-days: 3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,24 +12,31 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v7
+      # https://github.com/actions/checkout/releases
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
-      - uses: jdx/mise-action@v4
+      # https://github.com/jdx/mise-action/releases
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
-      - uses: actions/setup-go@v6
+      # https://github.com/actions/setup-go/releases
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           check-latest: true
           go-version-file: go.mod
 
-      - uses: docker/setup-qemu-action@v4
+      # https://github.com/docker/setup-qemu-action/releases
+      - uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
-      - uses: docker/setup-buildx-action@v4
+      # https://github.com/docker/setup-buildx-action/releases
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
+      # https://github.com/tibdex/github-app-token/releases
       - id: app_token
-        uses: tibdex/github-app-token@v2
+        uses: tibdex/github-app-token@3beb63f4bd073e61482598c45c71c1019b59b73a # v2.1.0
         with:
           app_id: ${{ secrets.TOKEN_APP_ID }}
           private_key: ${{ secrets.TOKEN_APP_PRIVATE_KEY }}
@@ -37,7 +44,8 @@ jobs:
       - name: Login to docker.io
         run: docker login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: goreleaser/goreleaser-action@v7
+      # https://github.com/goreleaser/goreleaser-action/releases
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
         with:
           version: '~> v2'
           args: release --clean

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,25 +18,31 @@ concurrency:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
+      # https://github.com/actions/checkout/releases
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - uses: jdx/mise-action@v4
+      # https://github.com/jdx/mise-action/releases
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
 
-      - uses: actions/setup-go@v6
+      # https://github.com/actions/setup-go/releases
+      - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           check-latest: true
           go-version-file: 'go.mod'
 
       - name: Setup golangci-lint cache
-        uses: actions/cache@v5
+        # https://github.com/actions/cache/releases
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
           path: ~/.cache/golangci-lint
           key: golangci-lint-${{ runner.os }}-${{ hashFiles('**/go.mod') }}
           restore-keys: |
             golangci-lint-${{ runner.os }}--
 
-      - uses: actions/setup-node@v6
+      # https://github.com/actions/setup-node/releases
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
 
       - name: Run yarn install
         working-directory: example
@@ -56,3 +62,11 @@ jobs:
 
       - name: Run tests
         run: make test
+
+      # https://github.com/codecov/codecov-action/releases
+      - uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        if: success() && github.ref == 'refs/heads/main'
+        with:
+          fail_ci_if_error: false
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.out

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,9 +1,14 @@
+#:schema https://mise.jdx.dev/schema/mise.json
+
+[settings]
+minimum_release_age = "3d"
+
 [tools]
 # https://mise-tools.jdx.dev/tools/bun
 bun = "1.3.14"
-# https://mise-tools.jdx.dev/tools/lefthook
-lefthook = "2.1.8"
 # https://mise-tools.jdx.dev/tools/golangci-lint
 golangci-lint = "2.12.2"
 # https://mise-tools.jdx.dev/tools/jsonschema
-jsonschema = "15.6.3"
+jsonschema = "16.0.0"
+# https://mise-tools.jdx.dev/tools/lefthook
+lefthook = "2.1.9"

--- a/Makefile
+++ b/Makefile
@@ -160,14 +160,14 @@ tidy:
 ## Show outdated direct dependencies
 outdated:
 	@echo "〉go mod outdated"
-	@go list -u -m -json all | go-mod-outdated -update -direct
+	@$(foreach mod,$(GOMODS), (cd $(dir $(mod)) && echo "📂 $(dir $(mod))" && go mod tidy && go list -u -m -json all | go-mod-outdated -update -direct) &&) true
 
 .PHONY: upgrade
-## Show outdated direct dependencies
+## Upgrade direct dependencies in all go.mod files
 upgrade:
 	@echo "〉go mod upgrade"
-	@go list -u -m -f '{{if and (not .Indirect) .Update}}{{.Path}}{{end}}' all | xargs -n1 -I{} go get {}@latest
-	@$(MAKE) tidy
+	@rm -f go.work go.work.sum
+	@$(foreach mod,$(GOMODS), (cd $(dir $(mod)) && echo "📂 $(dir $(mod))" && go mod tidy && deps=$$(go list -u -m -f '{{if and (not .Main) (not .Indirect) .Update}}{{.Path}}{{end}}' all); [ -z "$$deps" ] || for dep in $$deps; do go get "$$dep@latest"; done; go mod tidy) &&) true
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-[![Build Status](https://github.com/foomo/gotsrpc/actions/workflows/test.yml/badge.svg?branch=main&event=push)](https://github.com/foomo/gotsrpc/actions/workflows/test.yml)
-[![Go Report Card](https://goreportcard.com/badge/github.com/foomo/gotsrpc)](https://goreportcard.com/report/github.com/foomo/gotsrpc)
-[![GoDoc](https://godoc.org/github.com/foomo/gotsrpc?status.svg)](https://godoc.org/github.com/foomo/gotsrpc)
+[![GoDoc](https://img.shields.io/badge/GoDoc-✓-informational.svg?style=flat-square&logo=go)](https://godoc.org/github.com/foomo/gotsrpc)
+[![Coverage](https://img.shields.io/codecov/c/github/foomo/gotsrpc?style=flat-square&logo=github)](https://app.codecov.io/gh/foomo/gotsrpc)
+[![GitHub Downloads](https://img.shields.io/github/downloads/foomo/gotsrpc/total.svg?style=flat-square&logo=github)](https://github.com/foomo/gotsrpc/releases)
+[![Docker Pulls](https://img.shields.io/docker/pulls/foomo/gotsrpc.svg?style=flat-square&logo=docker)](https://hub.docker.com/r/foomo/gotsrpc)
+[![GitHub Stars](https://img.shields.io/github/stars/foomo/gotsrpc.svg?style=flat-square&logo=github)](https://github.com/foomo/gotsrpc)
 
 <p align="center">
   <img alt="gotsrpc" src="docs/public/logo.png" width="400" height="400"/>


### PR DESCRIPTION
### Description

Housekeeping across CI, dependency management, and tooling: pin all GitHub Actions to commit SHAs, restructure Dependabot to security-only grouped updates, refresh mise tool versions, improve the Makefile `outdated`/`upgrade` targets for multi-module workspaces, and modernize the README badges.

### Type of Change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance
- [ ] ✅ Tests
- [x] 🔧 Build/CI

### Changes

- **Dependabot**: switch to `json.schemastore.org` schema; add a `docker` ecosystem; move all ecosystems to daily, security-only grouped updates (`applies-to: security-updates`, grouped by dependency-name) with `sec(gha)`/`sec(gomod)`/`sec(docker)` commit prefixes; set `open-pull-requests-limit: 0` and a 3-day cooldown.
- **release.yml**: pin all actions to commit SHAs (with version comments), add `timeout-minutes: 30`.
- **test.yml**: pin all actions to commit SHAs, add `timeout-minutes: 15`, downgrade `pull-requests` permission from `write` to `read`, and add a Codecov upload step (main branch only).
- **.mise.toml**: add schema + `minimum_release_age = "3d"`; bump `jsonschema` 15.6.3 → 16.0.0 and `lefthook` 2.1.8 → 2.1.9.
- **Makefile**: rework `outdated` and `upgrade` to iterate over all `go.mod` files in the workspace.
- **README**: replace build/report-card badges with GoDoc, Coverage, Downloads, Docker Pulls, and Stars badges.

### Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
